### PR TITLE
Fix Paho C build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/externals/paho-mqtt-c"]
 	path = src/externals/paho-mqtt-c
-	url = https://github.com/eclipse/paho.mqtt.c.git
+	url = ../../eclipse/paho.mqtt.c.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,12 +11,12 @@
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v2.0
 # and Eclipse Distribution License v1.0 which accompany this distribution.
-# 
+#
 # The Eclipse Public License is available at
 #   http://www.eclipse.org/legal/epl-v20.html
 # and the Eclipse Distribution License is available at
 #   http://www.eclipse.org/org/documents/edl-v10.php.
-# 
+#
 # Contributors:
 #   Guilherme Maciel Ferreira - initial version
 #   Frank Pagliughi
@@ -50,6 +50,17 @@ endif()
 
 ## --- Find Paho C or build it, if reqested ---
 
+if(PAHO_WITH_SSL)
+  find_package(OpenSSL REQUIRED)
+  set(PAHO_MQTT_C_LIB paho-mqtt3as)
+else()
+  set(PAHO_MQTT_C_LIB paho-mqtt3a)
+endif()
+
+if(PAHO_BUILD_STATIC AND NOT PAHO_BUILD_SHARED)
+  set(PAHO_MQTT_C_LIB ${PAHO_MQTT_C_LIB}-static)
+endif()
+
 if(PAHO_WITH_MQTT_C)
   message(STATUS "Paho C: Bundled")
 
@@ -57,7 +68,7 @@ if(PAHO_WITH_MQTT_C)
   set(PAHO_ENABLE_TESTING FALSE CACHE BOOL "No Paho C tests")
   set(PAHO_HIGH_PERFORMANCE TRUE CACHE BOOL "Paho C high performance")
 
-  add_subdirectory(${PROJECT_SOURCE_DIR}/externals/paho-mqtt-c)
+  add_subdirectory(${PROJECT_SOURCE_DIR}/src/externals/paho-mqtt-c EXCLUDE_FROM_ALL)
 
   ## Alias namespace so that the full names can be used with the subdir.
   if(PAHO_BUILD_SHARED)
@@ -83,16 +94,7 @@ else()
   find_package(eclipse-paho-mqtt-c REQUIRED)
 endif()
 
-if(PAHO_WITH_SSL)
-  find_package(OpenSSL REQUIRED)
-  set(PAHO_MQTT_C_LIB eclipse-paho-mqtt-c::paho-mqtt3as)
-else()
-  set(PAHO_MQTT_C_LIB eclipse-paho-mqtt-c::paho-mqtt3a)
-endif()
-
-if(PAHO_BUILD_STATIC AND NOT PAHO_BUILD_SHARED)
-  set(PAHO_MQTT_C_LIB ${PAHO_MQTT_C_LIB}-static)
-endif()
+set(PAHO_MQTT_C_LIB "eclipse-paho-mqtt-c::${PAHO_MQTT_C_LIB}")
 
 ## --- C++11 build flags ---
 
@@ -161,4 +163,3 @@ endif()
 include(CPack)
 
 add_subdirectory(cmake)
-

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,13 +11,13 @@
 #
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v2.0
-#  and Eclipse Distribution License v1.0 which accompany this distribution. 
-# 
-#  The Eclipse Public License is available at 
+#  and Eclipse Distribution License v1.0 which accompany this distribution.
+#
+#  The Eclipse Public License is available at
 #     http://www.eclipse.org/legal/epl-v20.html
-#  and the Eclipse Distribution License is available at 
+#  and the Eclipse Distribution License is available at
 #    http://www.eclipse.org/org/documents/edl-v10.php.
-# 
+#
 #  Contributors:
 #     Guilherme Maciel Ferreira - initial version
 #     Frank Pagliughi - made the shared library optional
@@ -38,7 +38,7 @@ set(COMMON_SRC
   async_client.cpp
   client.cpp
   connect_options.cpp
-  create_options.cpp    
+  create_options.cpp
   disconnect_options.cpp
   iclient_persistence.cpp
   message.cpp
@@ -61,7 +61,6 @@ if(PAHO_BUILD_SHARED)
 
     ## Add dependencies to the shared library
     target_link_libraries(paho-mqttpp3 PUBLIC
-      eclipse-paho-mqtt-c::paho-mqtt3as
       ${PAHO_MQTT_C_LIB}
       Threads::Threads
     )
@@ -81,7 +80,7 @@ if(PAHO_BUILD_STATIC)
     list(APPEND PAHO_CPP_TARGETS paho-mqttpp3-static)
 
     ## add dependencies to the shared library
-    target_link_libraries(paho-mqttpp3-static PUBLIC 
+    target_link_libraries(paho-mqttpp3-static PUBLIC
       ${PAHO_MQTT_C_LIB}
       Threads::Threads
     )


### PR DESCRIPTION
This PR is mainly for fixing the CMake error when `PAHO_WITH_MQTT_C` is enabled.

I also changed the Git submodule URL to a relative path so that it can follow the same protocol used to clone the main repository.

Fixes #469.