### PR TITLE
Add function for checking async consumer event queue size

### DIFF
--- a/include/mqtt/async_client.h
+++ b/include/mqtt/async_client.h
@@ -801,6 +801,20 @@ public:
         return !que_ || que_->done();
     }
     /**
+     * Gets the number of events available for immediate consumption.
+     * Note that this retrieves the number of "raw" events, not messages,
+     * e.g. may include a connected_event which is not returned by try_consume_message().
+     * When polling the queue from multiple threads, prefer using try_consume_event(),
+     * as the event count may change between checking the size and actual retrieval.
+     * @return the number of events in the queue.
+     */
+    std::size_t consumer_events_available() const override {
+        if (que_)
+            return que_->size();
+        else
+            return 0;
+    }
+    /**
      * Read the next message from the queue.
      * This blocks until a new message arrives.
      * @return The message and topic.

--- a/include/mqtt/iasync_client.h
+++ b/include/mqtt/iasync_client.h
@@ -474,6 +474,15 @@ public:
         return false;
     }
     /**
+     * Gets the number of events available for immediate consumption.
+     * Note that this retrieves the number of "raw" events, not messages,
+     * e.g. may include a connected_event which is not returned by try_consume_message().
+     * When polling the queue from multiple threads, prefer using try_consume_event(),
+     * as the event count may change between checking the size and actual retrieval.
+     * @return the number of events in the queue.
+     */
+    virtual std::size_t consumer_events_available() const { return 0; }
+    /**
      * Read the next message from the queue.
      * This blocks until a new message arrives.
      * @return The message and topic.

--- a/test/unit/test_async_client.cpp
+++ b/test/unit/test_async_client.cpp
@@ -1006,3 +1006,23 @@ TEST_CASE("async_client consumer timeout", "[client]")
     cli.start_consuming();
     cli.try_consume_message_until(std::chrono::steady_clock::now());
 }
+
+TEST_CASE("async_client consumer events available", "[client]")
+{
+    async_client cli{GOOD_SERVER_URI, CLIENT_ID};
+    cli.start_consuming();
+    REQUIRE(0 == cli.consumer_events_available());
+
+    token_ptr conn_tok{cli.connect()};
+    REQUIRE(conn_tok);
+    conn_tok->wait();
+    REQUIRE(cli.is_connected());
+    // expect connected_event to be in the queue now
+    REQUIRE(1 == cli.consumer_events_available());
+    event e;
+    REQUIRE(cli.try_consume_event(&e));
+    REQUIRE(0 == cli.consumer_events_available());
+
+    cli.stop_consuming();
+    cli.disconnect()->wait();
+}


### PR DESCRIPTION
This adds a function `consumer_events_available()` on the async client to get the number of events available for consumption. Similar to e558946c1dd664214505b48ca769024c781a53a6 I've added a default impl to the interface to avoid breaking old code which inherits from it.

The idea behind this is to allow exposing some stats in metrics, i.e. to see when consumers are lagging behind in consuming/processing messages, and the "pending" event count goes up. It may be also useful in some scenarios when implementing polling consumers, although I expect that in most cases the existing try_consume... functions are still more appropriate there.