### PR TITLE
Update TEST_EXTERNAL_SERVER urls

### DIFF
--- a/test/unit/test_async_client.cpp
+++ b/test/unit/test_async_client.cpp
@@ -36,7 +36,8 @@ using namespace mqtt;
 // NOTE: This test case requires network access. It uses one of
 //  	 the public available MQTT brokers
 #if defined(TEST_EXTERNAL_SERVER)
-static const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
+static const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipseprojects.io:1883"};
+static const std::string GOOD_SSL_SERVER_URI{"ssl://mqtt.eclipseprojects.io:1885"};
 #else
 static const std::string GOOD_SERVER_URI{"tcp://localhost:1883"};
 static const std::string GOOD_SSL_SERVER_URI{"ssl://localhost:18885"};

--- a/test/unit/test_async_client_v3.cpp
+++ b/test/unit/test_async_client_v3.cpp
@@ -98,7 +98,7 @@ class async_client_v3_test : public CppUnit::TestFixture
 // NOTE: This test case requires network access. It uses one of
 //  	 the public available MQTT brokers
 #if defined(TEST_EXTERNAL_SERVER)
-    const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
+    const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipseprojects.io:1883"};
 #else
     const std::string GOOD_SERVER_URI{"tcp://localhost:1883"};
     const std::string GOOD_SSL_SERVER_URI{"ssl://localhost:18885"};

--- a/test/unit/test_client.cpp
+++ b/test/unit/test_client.cpp
@@ -40,7 +40,7 @@ using namespace mqtt;
 // NOTE: This test case requires network access. It uses one of
 //  	 the public available MQTT brokers
 #if defined(TEST_EXTERNAL_SERVER)
-static const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipse.org:1883"};
+static const std::string GOOD_SERVER_URI{"tcp://mqtt.eclipseprojects.io:1883"};
 #else
 static const std::string GOOD_SERVER_URI{"tcp://localhost:1883"};
 #endif


### PR DESCRIPTION
The Eclipse hosted MQTT public test broker that used to be at mqtt.eclipse.org has moved to mqtt.eclipseprojects.io.
See https://www.eclipse.org/lists/iot-wg/msg01733.html

Also adds missing `GOOD_SSL_SERVER_URI` when `TEST_EXTERNAL_SERVER` is set.