### PR TITLE
Enable build with macOS STL

### DIFF
--- a/include/mqtt/ssl_options.h
+++ b/include/mqtt/ssl_options.h
@@ -103,7 +103,7 @@ private:
     psk_handler pskHandler_;
 
     /** ALPN protocol list, in wire format */
-    std::basic_string<unsigned char> protos_;
+    std::vector<unsigned char> protos_;
 
     /** Callbacks from the C library */
     static int on_error(const char* str, size_t len, void* context);

--- a/src/ssl_options.cpp
+++ b/src/ssl_options.cpp
@@ -117,7 +117,7 @@ void ssl_options::update_c_struct()
 
     if (!protos_.empty()) {
         opts_.protos = protos_.data();
-        opts_.protos_len = unsigned(protos_.length());
+        opts_.protos_len = unsigned(protos_.size());
     }
     else {
         opts_.protos = nullptr;
@@ -299,7 +299,7 @@ void ssl_options::set_psk_handler(psk_handler cb)
 std::vector<string> ssl_options::get_alpn_protos() const
 {
     std::vector<string> protos;
-    size_t i = 0, n = protos_.length();
+    size_t i = 0, n = protos_.size();
 
     while (i < n) {
         size_t sn = protos_[i++];
@@ -324,7 +324,7 @@ void ssl_options::set_alpn_protos(const std::vector<string>& protos)
     using uchar = unsigned char;
 
     if (!protos.empty()) {
-        std::basic_string<uchar> protoBin;
+        std::vector<uchar> protoBin;
         for (const auto& proto : protos) {
             protoBin.push_back(uchar(proto.length()));
             for (const char c : proto) protoBin.push_back(uchar(c));
@@ -332,10 +332,10 @@ void ssl_options::set_alpn_protos(const std::vector<string>& protos)
         protos_ = std::move(protoBin);
 
         opts_.protos = protos_.data();
-        opts_.protos_len = unsigned(protos_.length());
+        opts_.protos_len = unsigned(protos_.size());
     }
     else {
-        protos_ = std::basic_string<uchar>();
+        protos_.clear();
         opts_.protos = nullptr;
         opts_.protos_len = 0;
     }


### PR DESCRIPTION
On macOS I ran into this build error:
```
In file included from src/topic.cpp:19:
In file included from include/mqtt/topic.h:27:
In file included from /Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/vector:325:
In file included from /Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__format/formatter_bool.h:19:
In file included from /Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__format/formatter_integral.h:21:
In file included from /Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__format/formatter_output.h:22:
In file included from /Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__format/parser_std_format_spec.h:39:
/Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/string:821:42: error: implicit instantiation of undefined template 'std::char_traits<unsigned char>'
  821 |   static_assert(is_same<_CharT, typename traits_type::char_type>::value,
      |                                          ^
include/mqtt/ssl_options.h:106:38: note: in instantiation of template class 'std::basic_string<unsigned char>' requested here
  106 |     std::basic_string<unsigned char> protos_;
      |                                      ^
/Users/laltenmueller/Downloads/Xcode-beta.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:23:29: note: template is declared here
   23 | struct _LIBCPP_TEMPLATE_VIS char_traits;
      |                             ^
1 error generated.
```

This PR fixes the error by changing the data type in ssl_options.h from std::basic_string<unsigned char> to std::vector<unsigned char> for the protos_ member variable. 

I updated all the related code in ssl_options.cpp to use vector operations instead of string operations (.size(), .clear())

The issue is that macOS's implementation of the C++ standard library seemingly doesn't provide a specialization of std::char_traits for unsigned char, which is required when using std::basic_string<unsigned char>.

Using a vector might be more appropriate for this use case anyway since we're dealing with raw byte data rather than character strings.