### PR TITLE
Prevent undefined behavior empty topic matching

### DIFF
--- a/src/topic.cpp
+++ b/src/topic.cpp
@@ -109,6 +109,11 @@ bool topic_filter::matches(const string& topic) const
 {
     auto n = fields_.size();
 
+    // Edge case of topic_filter("")
+    if (n == 0) {
+        return false;
+    }
+
     auto topic_fields = topic::split(topic);
     auto nt = topic_fields.size();
 
@@ -126,7 +131,7 @@ bool topic_filter::matches(const string& topic) const
     // MQTT v5 Spec, Section 4.7.2:
     // https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901246
 
-    if (n > 0 && is_wildcard(fields_[0]) && nt > 0 && topic_fields[0].size() > 0 &&
+    if (is_wildcard(fields_[0]) && nt > 0 && topic_fields[0].size() > 0 &&
         topic_fields[0][0] == '$') {
         return false;
     }

--- a/test/unit/test_topic.cpp
+++ b/test/unit/test_topic.cpp
@@ -273,5 +273,8 @@ TEST_CASE("topic matches", "[topic_filter]")
         REQUIRE(!topic_filter{"#"}.matches("$SYS/bar"));
         REQUIRE(!topic_filter{"$BOB/bar"}.matches("$SYS/bar"));
         REQUIRE(!topic_filter{"+/bar"}.matches("$SYS/bar"));
+        REQUIRE(!topic_filter{""}.matches("foo"));
+        REQUIRE(!topic_filter{""}.matches("foo/bar"));
+        REQUIRE(!topic_filter{"foo/bar"}.matches(""));
     }
 }


### PR DESCRIPTION
I'm using the filter in an object where it should start "uninitialized" until it is able to define its wildcard. In order to achieve that, I need an "unmatchable" topic. However ``topic_filter("")`` yields ``n=0``:

 https://github.com/eclipse-paho/paho.mqtt.cpp/blob/17ff3dc0270738adc710667be44847eebc038ae0/src/topic.cpp#L108-L110 

 leading to undefined behaviour on:

 https://github.com/eclipse-paho/paho.mqtt.cpp/blob/17ff3dc0270738adc710667be44847eebc038ae0/src/topic.cpp#L121-L122 

This PR only leads to (negligible) cost increase to the case of matching shorter topics and longer topics with '#' wildcard:

 https://github.com/eclipse-paho/paho.mqtt.cpp/blob/17ff3dc0270738adc710667be44847eebc038ae0/src/topic.cpp#L115-L123